### PR TITLE
Example for a child which should absorb all gestures and not allow the parents to scroll

### DIFF
--- a/lib/modules/lab/pages/lab_page.dart
+++ b/lib/modules/lab/pages/lab_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:hand_signature/signature.dart';
 
@@ -60,9 +61,17 @@ class _SignatureSectionState extends State<SignatureSection> {
       color: Colors.grey[200],
       height: 300,
       width: 300,
-      child: HandSignature(
-        control: control,
-        type: SignatureDrawType.shape,
+      child: RawGestureDetector(
+        gestures: {
+          EagerGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<EagerGestureRecognizer>(
+                  () => EagerGestureRecognizer(),
+                  (EagerGestureRecognizer instance) {})
+        },
+        child: HandSignature(
+          control: control,
+          type: SignatureDrawType.shape,
+        ),
       ),
     );
   }

--- a/lib/modules/lab/pages/lab_page.dart
+++ b/lib/modules/lab/pages/lab_page.dart
@@ -1,12 +1,69 @@
 import 'package:flutter/material.dart';
+import 'package:hand_signature/signature.dart';
 
 class LabPage extends StatelessWidget {
   const LabPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Play around with gestures on this page'),
+    return DefaultTabController(
+      initialIndex: 1,
+      length: 3,
+      child: TabBarView(
+        children: [
+          Container(height: 200, color: Colors.pink),
+          ListView(
+            children: [
+              Column(
+                children: [
+                  Row(
+                    children: const [
+                      Flexible(
+                        child: Text(
+                            'The grey section is the signature pad which should absorb all gestures, on mobile this will look a bit funky at the moment'),
+                      ),
+                    ],
+                  ),
+                  const SignatureSection(),
+                  ...List.generate(
+                    20,
+                    (index) {
+                      return Container(height: 300, width: 300, color: index.isEven ? Colors.red : Colors.blue);
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+          Container(height: 200, color: Colors.green),
+        ],
+      ),
+    );
+  }
+}
+
+class SignatureSection extends StatefulWidget {
+  const SignatureSection({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<SignatureSection> createState() => _SignatureSectionState();
+}
+
+class _SignatureSectionState extends State<SignatureSection> {
+  final control = HandSignatureControl();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.grey[200],
+      height: 300,
+      width: 300,
+      child: HandSignature(
+        control: control,
+        type: SignatureDrawType.shape,
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -111,6 +111,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -137,6 +144,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  hand_signature:
+    dependency: "direct main"
+    description:
+      name: hand_signature
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.0+1"
   http_multi_server:
     dependency: transitive
     description:
@@ -235,6 +249,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0"
   pool:
     dependency: transitive
     description:
@@ -394,6 +429,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   yaml:
     dependency: transitive
     description:
@@ -403,3 +445,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.17.5 <3.0.0"
+  flutter: ">=2.11.0-0.1.pre"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   mocktail: ^0.3.0
   font_awesome_flutter: ^10.2.1
+  hand_signature: ^2.3.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Here I'm using a signature pad which on mobile should absorb all gestures and not allow the parents to scroll while the signing gesture is active. This only works on touch devices since it's the touch gestures which are competing - on desktop everything works as expected.

The only workaround I could find looks like this and uses a state object to modify the scroll behaviour of the parents:
https://github.com/RomanBase/hand_signature/blob/master/example/lib/scroll_test.dart 

<img width="744" alt="image" src="https://user-images.githubusercontent.com/13539680/189343791-f9685eee-2332-4f96-91ef-a19635fc4c38.png">
